### PR TITLE
Fix: Used platform-aware camera backend for macOS AVFoundation support

### DIFF
--- a/yolo_studio/ui/tabs/camera_tab.py
+++ b/yolo_studio/ui/tabs/camera_tab.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -34,6 +35,21 @@ from sqlalchemy.orm import joinedload
 
 LOGGER = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _preferred_camera_backend() -> int:
+    """Return the preferred OpenCV camera backend for the current platform.
+
+    macOS  -> CAP_AVFOUNDATION (native AVFoundation framework)
+    Linux  -> CAP_V4L2         (Video4Linux2)
+    Other  -> CAP_ANY          (let OpenCV auto-detect)
+    """
+
+    if sys.platform == "darwin":
+        return cv2.CAP_AVFOUNDATION
+    if sys.platform.startswith("linux"):
+        return cv2.CAP_V4L2
+    return cv2.CAP_ANY
 
 
 @dataclass(slots=True)
@@ -123,7 +139,7 @@ class CameraStreamWorker(QThread):
             self.error.emit(f"Ultralytics is unavailable: {exc}")
             return
 
-        capture = cv2.VideoCapture(self._device_index)
+        capture = cv2.VideoCapture(self._device_index, _preferred_camera_backend())
         if not capture.isOpened():
             self.error.emit(f"Unable to open camera device {self._device_index}.")
             return
@@ -550,7 +566,7 @@ class CameraTab(QWidget):
         indices = []
         consecutive_misses = 0
         max_probes = 12
-        backend = cv2.CAP_V4L2 if hasattr(cv2, "CAP_V4L2") else cv2.CAP_ANY
+        backend = _preferred_camera_backend()
 
         for idx in range(max_probes):
             cap = cv2.VideoCapture(idx, backend)


### PR DESCRIPTION
**TLDR: Camera’s weren’t getting detected on MacOS M1 Sequoia 15.3, system seemed optimised for Linux.**

## Problem

The Camera tab fails to detect any webcam devices on macOS. The device
dropdown shows "No devices detected" and the stream cannot start.

**Root cause:** `CameraTab.refresh_devices()` selects the OpenCV capture
backend with:
```python
backend = cv2.CAP_V4L2 if hasattr(cv2, "CAP_V4L2") else cv2.CAP_ANY
```

`cv2.CAP_V4L2` is a numeric constant that exists in OpenCV on every
platform, so `hasattr()` always returns `True`. However, the V4L2
*driver* is Linux-only. On macOS, every `VideoCapture(idx, CAP_V4L2)`
probe fails because there is no V4L2 subsystem — macOS uses
AVFoundation.

The same issue affects `CameraStreamWorker.run()`, which called
`VideoCapture(index)` without specifying any backend, leading to
inconsistent behaviour across platforms.

## Solution

Added a `_preferred_camera_backend()` helper that returns the correct
OpenCV backend constant per platform:

| Platform | Backend              |
|----------|----------------------|
| macOS    | `CAP_AVFOUNDATION`  |
| Linux    | `CAP_V4L2`          |
| Other    | `CAP_ANY`            |

Both `VideoCapture` call sites (device enumeration and stream capture)
now use this helper.

## Testing

- **macOS 15.3 (M1):** Camera tab detects built-in webcam and
  Continuity Camera devices. Stream starts and produces frames.
- **Linux:** No behavioural change — helper returns `CAP_V4L2`, matching
  the previous hardcoded default.

## Changes

- `yolo_studio/ui/tabs/camera_tab.py` — 1 file, 18 insertions,
  2 deletions