### PR TITLE
Harden edge agent defaults + limit websocket/model sizes

### DIFF
--- a/yolo_studio/core/services/remote_manager.py
+++ b/yolo_studio/core/services/remote_manager.py
@@ -22,6 +22,8 @@ from typing import Any, Callable
 LOGGER = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT_ROOT = PROJECT_ROOT / "runs" / "remote_results"
+# Keep bounded to avoid memory DoS on clients.
+MAX_WS_MESSAGE_SIZE = 100 * 1024 * 1024  # 100 MiB
 
 
 class RemoteManagerError(RuntimeError):
@@ -623,7 +625,7 @@ class RemoteManager:
                 close_timeout=resolved_timeout,
                 ping_interval=20,
                 ping_timeout=20,
-                max_size=None,
+                max_size=MAX_WS_MESSAGE_SIZE,
             ) as ws:
                 await ws.send(json.dumps(message))
                 raw = await asyncio.wait_for(ws.recv(), timeout=resolved_timeout)
@@ -670,7 +672,7 @@ class RemoteManager:
                 close_timeout=resolved_timeout,
                 ping_interval=20,
                 ping_timeout=20,
-                max_size=None,
+                max_size=MAX_WS_MESSAGE_SIZE,
             ) as ws:
                 await ws.send(json.dumps(message))
 
@@ -756,7 +758,7 @@ class RemoteManager:
                 close_timeout=resolved_timeout,
                 ping_interval=20,
                 ping_timeout=20,
-                max_size=None,
+                max_size=MAX_WS_MESSAGE_SIZE,
             ) as ws:
                 await ws.send(json.dumps(message))
 

--- a/yolo_studio/edge/agent_config.yaml
+++ b/yolo_studio/edge/agent_config.yaml
@@ -1,9 +1,19 @@
 # YOLO Studio edge agent configuration
 # Update auth_token before deploying this on a real network.
 
-host: "0.0.0.0"
+# Security: bind to loopback by default. Set to 0.0.0.0 only if you understand the risks.
+host: "127.0.0.1"
 port: 8765
+# Security: you MUST change this before exposing the agent to other machines.
 auth_token: "change-me-before-production"
+
+# Maximum accepted websocket message size (bytes). Keep this bounded to avoid DoS.
+max_message_size: 104857600  # 100 MiB
+# Maximum allowed model upload size (bytes, decoded). Prevents disk fill.
+max_model_bytes: 52428800    # 50 MiB
+
+# Allow loading pickle-backed PyTorch .pt models (RCE risk). Prefer ONNX.
+allow_unsafe_pytorch_pt: false
 
 # Relative paths are resolved from this file's directory.
 model_cache_dir: "./model_cache"

--- a/yolo_studio/edge/jetson_agent.py
+++ b/yolo_studio/edge/jetson_agent.py
@@ -52,6 +52,7 @@ except Exception as exc:  # pragma: no cover - dependency import guard
 
 LOGGER = logging.getLogger("yolo_studio.edge.agent")
 DEFAULT_CONFIG_PATH = Path(__file__).with_name("agent_config.yaml")
+DEFAULT_AUTH_TOKEN = "change-me-before-production"
 SUPPORTED_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".webp", ".tif", ".tiff"}
 
 
@@ -66,6 +67,9 @@ class AgentConfig:
     output_dir: Path
     chunk_size: int
     log_file: Path
+    max_message_size: int
+    max_model_bytes: int
+    allow_unsafe_pytorch_pt: bool
 
     @classmethod
     def from_yaml(cls, config_path: Path) -> "AgentConfig":
@@ -91,7 +95,7 @@ class AgentConfig:
 
         base_dir = config_path.resolve().parent
 
-        host = str(raw.get("host") or "0.0.0.0").strip()
+        host = str(raw.get("host") or "127.0.0.1").strip()
         port = int(raw.get("port") or 8765)
         auth_token = str(raw.get("auth_token") or "").strip()
 
@@ -100,14 +104,27 @@ class AgentConfig:
         log_file = _resolve_path(base_dir, raw.get("log_file") or "./agent.log")
         chunk_size = int(raw.get("chunk_size") or 200_000)
 
+        max_message_size = int(raw.get("max_message_size") or 100 * 1024 * 1024)
+        max_model_bytes = int(raw.get("max_model_bytes") or 50 * 1024 * 1024)
+        allow_unsafe_pytorch_pt = bool(raw.get("allow_unsafe_pytorch_pt") or False)
+
         if not host:
             raise ValueError("Config 'host' must be set.")
         if port <= 0 or port > 65535:
             raise ValueError("Config 'port' must be between 1 and 65535.")
         if not auth_token:
             raise ValueError("Config 'auth_token' must be set.")
+        if auth_token == DEFAULT_AUTH_TOKEN:
+            raise ValueError(
+                "Config 'auth_token' is still set to the insecure default. "
+                "Generate a strong token before starting the agent."
+            )
         if chunk_size < 1_024:
             raise ValueError("Config 'chunk_size' must be at least 1024 bytes.")
+        if max_message_size < 1_024 * 1024:
+            raise ValueError("Config 'max_message_size' must be at least 1MiB.")
+        if max_model_bytes < 1_024 * 1024:
+            raise ValueError("Config 'max_model_bytes' must be at least 1MiB.")
 
         model_cache_dir.mkdir(parents=True, exist_ok=True)
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -121,6 +138,9 @@ class AgentConfig:
             output_dir=output_dir,
             chunk_size=chunk_size,
             log_file=log_file,
+            max_message_size=max_message_size,
+            max_model_bytes=max_model_bytes,
+            allow_unsafe_pytorch_pt=allow_unsafe_pytorch_pt,
         )
 
 
@@ -161,7 +181,7 @@ class EdgeAgent:
             self._handle_connection,
             self._config.host,
             self._config.port,
-            max_size=None,
+            max_size=self._config.max_message_size,
             ping_interval=20,
             ping_timeout=20,
         ):
@@ -294,6 +314,19 @@ class EdgeAgent:
 
         if not model_bytes:
             raise ValueError("Decoded model payload is empty.")
+
+        if len(model_bytes) > self._config.max_model_bytes:
+            raise ValueError(
+                f"Model payload too large ({len(model_bytes)} bytes). "
+                f"Max allowed is {self._config.max_model_bytes} bytes."
+            )
+
+        suffix = Path(model_name).suffix.lower()
+        if suffix == ".pt" and not self._config.allow_unsafe_pytorch_pt:
+            raise ValueError(
+                "Refusing to deploy PyTorch .pt weights because they can be pickle-backed and unsafe. "
+                "Convert to ONNX or set allow_unsafe_pytorch_pt: true in agent_config.yaml (at your own risk)."
+            )
 
         # Model names are sanitized to avoid path traversal in cache output.
         destination = self._config.model_cache_dir / Path(model_name).name


### PR DESCRIPTION
Fixes #3.\nFixes #4.\nFixes #6.\n\nChanges:\n- Edge agent defaults to 127.0.0.1 and refuses to start with the insecure default token.\n- Add max websocket message size + max model upload bytes; enforce in server and client.\n- Refuse deploying .pt weights by default (RCE risk); require explicit allow_unsafe_pytorch_pt=true to opt in.\n\nNotes:\n- This keeps the agent secure-by-default. If you need LAN exposure, set host to 0.0.0.0 and configure TLS/reverse-proxy accordingly.